### PR TITLE
Support for multiple milestones statistics summarization

### DIFF
--- a/stats/client.py
+++ b/stats/client.py
@@ -40,14 +40,16 @@ parser=argparse.ArgumentParser(
     description='''Script used to generate a WebOps Sprint Report''', epilog="""All that's well, ends well.""")
 parser.add_argument('--user', help='User to login on GitHub', required=True)
 parser.add_argument('--passwd', help='Password to login on GitHub', required=True)
-parser.add_argument('--milestones', help='Milestone to be Analized, sepparated by comma', required=True)
+
 parser.add_argument('--repo', help='Repository to be analyzed', required=True)
+parser.add_argument('--milestones', help='Comma sepparated milestones to be analized', required=True)
 
 args=parser.parse_args()
 
 user = args.user
 passwd = args.passwd
 milestones = args.milestones.split(',')
+
 repository_name = args.repo
 useragent = "Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3"
 reativo = "inc: Reativo"


### PR DESCRIPTION
1) Adding support to process one or more milestones.
2) Adding statistics to "Top time consuming issues"
#### Usage:

```
usage: client.py [-h] --user USER --passwd PASSWD --repo REPO --milestones
                 MILESTONES

Script used to generate a WebOps Sprint Report

optional arguments:
  -h, --help            show this help message and exit
  --user USER           User to login on GitHub
  --passwd PASSWD       Password to login on GitHub
  --repo REPO           Repository to be analyzed
  --milestones MILESTONES
                        Comma sepparated milestones to be analyzed

All that's well, ends well.
```
#### Example of usage:

```
python client.py --user frmaia --passwd passwd --repo sambatech/webops --milestones 82,83,84,85
Processing Issues to milestone Release 4 - Sprint 1 - 09/06 à 13/06
Processing Issues to milestone Release 4 - Sprint 2 - 16/06 à 20/06
Processing Issues to milestone Release 4 - Sprint 3 - 23/06 à 27/06
Processing Issues to milestone Release 4 - Sprint 4 - 30/06 à 04/07
=========== Milestone(s) Statistics ===========

........... Task Summary ...........
[ ... ]
........... Top time consuming issues ........... (NEW)
[ ... ]
```
